### PR TITLE
Fix generator expression error w/ list comprehension

### DIFF
--- a/py/expression_handlers.py
+++ b/py/expression_handlers.py
@@ -102,9 +102,11 @@ class FlipHandler(NormHandler):
             return torch.flip(tensor, (dim,))
         result = tensor.detach().clone()
         pivot = tensor.shape[dim] // 2
-        out_slice = [np.s_[:] if d != dim else np.s_[pivot:] for d in range(tensor.ndim)]
-        in_slice = [np.s_[:] if d != dim else np.s_[:pivot] for d in range(tensor.ndim)]
-        result[tuple(out_slice)] = torch.flip(tensor[tuple(in_slice)], dims=(dim,))
+        out_slice = tuple(
+            np.s_[:] if d != dim else np.s_[pivot:] for d in range(tensor.ndim)
+        )
+        in_slice = tuple(np.s_[:] if d != dim else np.s_[:pivot] for d in range(tensor.ndim))
+        result[out_slice] = torch.flip(tensor[in_slice], dims=(dim,))
         return result
 
 

--- a/py/expression_handlers.py
+++ b/py/expression_handlers.py
@@ -10,6 +10,7 @@ from . import latent
 from .external import MODULES as EXT
 from .utils import scale_noise, resolve_value
 from .latent import OCSTAESD, ImageBatch
+from typing import Dict,Tuple,Optional,List
 
 ALLOW_UNSAFE = os.environ.get("COMFYUI_OCS_ALLOW_UNSAFE_EXPRESSIONS") is not None
 ALLOW_ALL_UNSAFE = os.environ.get("COMFYUI_OCS_ALLOW_ALL_UNSAFE") is not None
@@ -102,11 +103,9 @@ class FlipHandler(NormHandler):
             return torch.flip(tensor, (dim,))
         result = tensor.detach().clone()
         pivot = tensor.shape[dim] // 2
-        out_slice = (
-            np.s_[:] if d != dim else np.s_[pivot:] for d in range(tensor.ndim)
-        )
-        in_slice = (np.s_[:] if d != dim else np.s_[:pivot] for d in range(tensor.ndim))
-        result[*out_slice] = torch.flip(tensor[*in_slice], dims=(dim,))
+        out_slice = [np.s_[:] if d != dim else np.s_[pivot:] for d in range(tensor.ndim)]
+        in_slice = [np.s_[:] if d != dim else np.s_[:pivot] for d in range(tensor.ndim)]
+        result[tuple(out_slice)] = torch.flip(tensor[tuple(in_slice)], dims=(dim,))
         return result
 
 

--- a/py/expression_handlers.py
+++ b/py/expression_handlers.py
@@ -10,7 +10,6 @@ from . import latent
 from .external import MODULES as EXT
 from .utils import scale_noise, resolve_value
 from .latent import OCSTAESD, ImageBatch
-from typing import Dict,Tuple,Optional,List
 
 ALLOW_UNSAFE = os.environ.get("COMFYUI_OCS_ALLOW_UNSAFE_EXPRESSIONS") is not None
 ALLOW_ALL_UNSAFE = os.environ.get("COMFYUI_OCS_ALLOW_ALL_UNSAFE") is not None


### PR DESCRIPTION
Original code throws an error:

```
Traceback (most recent call last):
...
  File "comfyui_overly_complicated_sampling\py\expression_handlers.py", line 109
    result[*out_slice] = torch.flip(tensor[*in_slice], dims=(dim,))
           ^
SyntaxError: invalid syntax
```

Fix:
```
result[tuple(out_slice)] = torch.flip(tensor[tuple(in_slice)], dims=(dim,))
```